### PR TITLE
feat: ccguard_convert go exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,28 @@ ccguard_server
 
 You could be interested to know how to [setup the server](https://github.com/nilleb/ccguard/blob/master/docs/server-setup/server-setup-ubuntu.sh).
 
+## convert a report
+
+Sometimes you need to convert a report from a format to another. ccguard_convert is here to help!
+
+```sh
+# convert the report from golang textual format to cobertura.xml
+ccguard_convert golang-coverage-report.txt -if go -of xml -o output.xml
+
+# convert the report from cobertura xml format to html (pycobertura)
+ccguard_convert cobertura.xml -if xml -of html -o output.html
+
+# convert the report from golang textual format to html (pycobertura)
+ccguard_convert golang-coverage-report.txt -if go -of html -o output.html
+
+# you can add a .ccguard.config.json in the same directory of the report or to your home directory to fine tune the exclusions
+echo '{"convert.exclusions.go": ["**/config/default.go"]}' > .ccguard.config.json
+# the report will not contain the files matching the glob expression
+ccguard_convert golang-coverage-report.txt -if go -of xml -o output.xml
+```
+
+To know more about glob expressions, see `man 3 fnmatch`.
+
 ## expose a status badge
 
 Add the following Markdown to your README.md

--- a/ccguard/__init__.py
+++ b/ccguard/__init__.py
@@ -15,4 +15,4 @@ from .ccguard import (  # noqa
     get_output,
 )
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/ccguard/ccguard_convert.py
+++ b/ccguard/ccguard_convert.py
@@ -166,7 +166,7 @@ def parse_args(args=None):
         "-if",
         "--input-format",
         dest="input_format",
-        help="The format of the input report. (Supported: go)",
+        help="The format of the input report. (Supported: go, xml)",
     )
 
     parser.add_argument(

--- a/ccguard/ccguard_convert.py
+++ b/ccguard/ccguard_convert.py
@@ -8,9 +8,12 @@ from lxml import objectify
 import ccguard
 from pycobertura import Cobertura
 from pycobertura.reporters import HtmlReporter
+from fnmatch import fnmatch
 
 
-def convert_golang_report(report, log_function=print):
+def convert_golang_report(report, log_function=print, config=None):
+    config = config if config else ccguard.configuration(os.path.dirname(report))
+    exclusions = config.get("convert.exclusions.go", [])
     # name.go:line.column,line.column numberOfStatements count
 
     pattern = (
@@ -29,6 +32,15 @@ def convert_golang_report(report, log_function=print):
                 continue
 
             filename = match.group("filename")
+            exclude = False
+            for exclusion in exclusions:
+                if fnmatch(filename, exclusion):
+                    exclude |= True
+                    break
+
+            if exclude:
+                continue
+
             line_begins = int(match.group("line_begins"))
             # column_begins = match.group("column_begins")
             line_ends = int(match.group("line_ends"))

--- a/ccguard/test_ccguard_convert.py
+++ b/ccguard/test_ccguard_convert.py
@@ -10,3 +10,20 @@ def test_convert_go_xml():
     assert os.path.exists(outpath)
     xml = ET.parse(outpath).getroot()
     assert float(xml.get("line-rate"))
+
+
+def test_exclusions():
+    path = "ccguard/test_data/convert/go-coverage.txt"
+    (
+        report,
+        rate,
+        covered,
+        total,
+        packages,
+        packages_coverage,
+        files,
+        file_coverage,
+    ) = ccguard_convert.convert_golang_report(
+        path, config={"convert.exclusions.go": ["**/config/default.go"]}
+    )
+    assert not [fp for fp in files if "default.go" in fp]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ccguard",
-    version="0.6.0",
+    version="0.6.1",
     entry_points={
         "console_scripts": [
             "ccguard=ccguard.ccguard:main",


### PR DESCRIPTION
Allow the ccguard_convert caller configure exclusions for the given repository.

Please refer to the README.md to see how exclusions should be configured.

Implements #32 (in the fastest and shortest way possible, not exactly the one suggested by the beta tester)