### PR TITLE
fix: desambiguate repository

### DIFF
--- a/ccguard/__init__.py
+++ b/ccguard/__init__.py
@@ -15,4 +15,4 @@ from .ccguard import (  # noqa
     get_output,
 )
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/ccguard/__init__.py
+++ b/ccguard/__init__.py
@@ -1,6 +1,6 @@
 from .ccguard import (  # noqa
     SqliteAdapter,
-    RedisAdapter,
+    WebAdapter,
     ReferenceAdapter,
     configuration,
     GitAdapter,

--- a/ccguard/ccguard_convert.py
+++ b/ccguard/ccguard_convert.py
@@ -200,7 +200,9 @@ def main(args=None):
         else:
             write(args.output, ET.tostring(xml, pretty_print=True))
     elif args.output_format == "html":
-        source = ccguard.GitAdapter(os.path.dirname(args.report) or ".").get_root_path()
+        source = ccguard.GitAdapter(
+            os.path.dirname(args.report) or ".", args.repository_id_modifier
+        ).get_root_path()
         challenger = Cobertura(args.report, source=source)
         report = HtmlReporter(challenger)
         if not args.output:

--- a/ccguard/ccguard_diff.py
+++ b/ccguard/ccguard_diff.py
@@ -12,12 +12,13 @@ def print_diff_report(
     adapter,
     repository=".",
     repository_id_modifier=None,
+    subtype=None,
     pattern=None,
     log_function=print,
 ):
     dest = (pattern or "diff-{}-{}.html").format(first_ref, second_ref)
-    fdata = adapter.retrieve_cc_data(first_ref)
-    sdata = adapter.retrieve_cc_data(second_ref)
+    fdata = adapter.retrieve_cc_data(first_ref, subtype=subtype)
+    sdata = adapter.retrieve_cc_data(second_ref, subtype=subtype)
     first_fd = io.BytesIO(fdata)
     second_fd = io.BytesIO(sdata)
     source = ccguard.GitAdapter(repository, repository_id_modifier).get_root_path()
@@ -82,7 +83,7 @@ def main(args=None, log_function=print):
     second = ccguard.get_output(command, args.repository).rstrip("\n")
 
     with adapter_class(repo_id, config) as adapter:
-        refs = adapter.get_cc_commits()
+        refs = adapter.get_cc_commits(subtype=args.subtype)
         first_ref, second_ref = None, None
 
         for ref in refs:
@@ -100,6 +101,7 @@ def main(args=None, log_function=print):
                 adapter=adapter,
                 repository=args.repository,
                 repository_id_modifier=args.repository_id_modifier,
+                subtype=args.subtype,
                 pattern=args.report_file,
                 log_function=log_function,
             )

--- a/ccguard/ccguard_diff.py
+++ b/ccguard/ccguard_diff.py
@@ -7,14 +7,20 @@ import ccguard
 
 
 def print_diff_report(
-    first_ref, second_ref, adapter, repository=".", pattern=None, log_function=print
+    first_ref,
+    second_ref,
+    adapter,
+    repository=".",
+    repository_id_modifier=None,
+    pattern=None,
+    log_function=print,
 ):
     dest = (pattern or "diff-{}-{}.html").format(first_ref, second_ref)
     fdata = adapter.retrieve_cc_data(first_ref)
     sdata = adapter.retrieve_cc_data(second_ref)
     first_fd = io.BytesIO(fdata)
     second_fd = io.BytesIO(sdata)
-    source = ccguard.GitAdapter(repository).get_root_path()
+    source = ccguard.GitAdapter(repository, repository_id_modifier).get_root_path()
     log_function(
         "Printing the diff report for the commits {} and {} to {}".format(
             first_ref, second_ref, dest
@@ -65,7 +71,9 @@ def main(args=None, log_function=print):
         return -1
 
     config = ccguard.configuration(args.repository)
-    repo_id = ccguard.GitAdapter(args.repository).get_repository_id()
+    repo_id = ccguard.GitAdapter(
+        args.repository, args.repository_id_modifier
+    ).get_repository_id()
 
     command = "git rev-parse {}".format(first)
     first = ccguard.get_output(command, args.repository).rstrip("\n")
@@ -91,6 +99,7 @@ def main(args=None, log_function=print):
                 second_ref,
                 adapter=adapter,
                 repository=args.repository,
+                repository_id_modifier=args.repository_id_modifier,
                 pattern=args.report_file,
                 log_function=log_function,
             )

--- a/ccguard/ccguard_log.py
+++ b/ccguard/ccguard_log.py
@@ -6,9 +6,13 @@ import logging
 from xml.etree import ElementTree
 
 
-def dump(repo_folder=".", adapter_class=ccguard.SqliteAdapter):
+def dump(
+    repo_folder=".", repository_id_modifier=None, adapter_class=ccguard.SqliteAdapter
+):
     config = ccguard.configuration(repo_folder)
-    repo_id = ccguard.GitAdapter(repo_folder).get_repository_id()
+    repo_id = ccguard.GitAdapter(
+        repo_folder, repository_id_modifier
+    ).get_repository_id()
     with adapter_class(repo_id, config) as adapter:
         return adapter.dump()
 
@@ -52,9 +56,18 @@ class AnnotatedCommit(git.Commit):
         return self.pretty
 
 
-def detailed_references(repo_folder=".", limit=30, adapter_class=ccguard.SqliteAdapter):
+def detailed_references(
+    repo_folder=".",
+    repository_id_modifier=None,
+    limit=30,
+    adapter_class=ccguard.SqliteAdapter,
+):
     repo = git.Repo(repo_folder, search_parent_directories=True)
-    dumps = dump(repo_folder=repo_folder, adapter_class=adapter_class)
+    dumps = dump(
+        repo_folder=repo_folder,
+        repository_id_modifier=repository_id_modifier,
+        adapter_class=adapter_class,
+    )
     references = {ref: data for ref, data in dumps}
     logging.debug(references)
 
@@ -94,7 +107,10 @@ def main(args=None, logging_function=print):
     adapter_class = ccguard.adapter_factory(args.adapter, config)
 
     for ac in detailed_references(
-        repo_folder=args.repository, limit=args.limit, adapter_class=adapter_class
+        repo_folder=args.repository,
+        repository_id_modifier=args.repository_id_modifier,
+        limit=args.limit,
+        adapter_class=adapter_class,
     ):
         logging_function(ac)
 

--- a/ccguard/ccguard_server_blueprints.py
+++ b/ccguard/ccguard_server_blueprints.py
@@ -508,7 +508,7 @@ def api_references_debug(repository_id):
     return jsonify({"repository_id": repository_id, "data": output})
 
 
-BADGE_FORMAT = """<svg xmlns="http://www.w3.org/2000/svg" width="112" height="20">
+BADGE_FORMAT = """<svg xmlns="http://www.w3.org/2000/svg" width="96" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -531,7 +531,7 @@ BADGE_FORMAT = """<svg xmlns="http://www.w3.org/2000/svg" width="112" height="20
 </svg>
 """
 
-BADGE_UNKNOWN = """<svg xmlns="http://www.w3.org/2000/svg" width="137" height="20">
+BADGE_UNKNOWN = """<svg xmlns="http://www.w3.org/2000/svg" width="121" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -573,6 +573,7 @@ def get_last_commit(adapter, branch=None):
 
 @api_v1.route("/repositories/<string:repository_id>/status_badge.svg", methods=["GET"])
 def api_status_badge(repository_id):
+    logging.warning(request.headers.get("Referer", None))
     branch = request.args.get("branch") or "master"
     red = request.args.get("red") or "red"
     green = request.args.get("green") or "green"

--- a/ccguard/ccguard_show.py
+++ b/ccguard/ccguard_show.py
@@ -19,6 +19,7 @@ def print_report(
     adapter,
     repository=".",
     repository_id_modifier=None,
+    subtype=None,
     pattern=None,
     log_function=print,
 ):
@@ -27,7 +28,7 @@ def print_report(
         "Printing the coverage report for the commit {} to {}".format(commit_id, dest)
     )
 
-    data = adapter.retrieve_cc_data(commit_id)
+    data = adapter.retrieve_cc_data(commit_id, subtype=subtype)
     reference_fd = io.BytesIO(data)
     source = ccguard.GitAdapter(repository, repository_id_modifier).get_root_path()
     reference_fd = normalize_report_paths(reference_fd, source)
@@ -77,7 +78,7 @@ def main(args=None, log_function=print):
     args.commit_id = ccguard.get_output(command, args.repository).rstrip("\n")
 
     with adapter_class(repo_id, config) as adapter:
-        refs = adapter.get_cc_commits()
+        refs = adapter.get_cc_commits(subtype=args.subtype)
 
         first_ref = None
         for ref in refs:
@@ -91,6 +92,7 @@ def main(args=None, log_function=print):
                 adapter=adapter,
                 repository=args.repository,
                 repository_id_modifier=args.repository_id_modifier,
+                subtype=args.subtype,
                 pattern=args.report_file,
                 log_function=log_function,
             )

--- a/ccguard/ccguard_sync.py
+++ b/ccguard/ccguard_sync.py
@@ -7,8 +7,8 @@ def transfer(
     commit_id,
     repo_folder=".",
     repository_id_modifier=None,
-    source_adapter_class=ccguard.SqliteAdapter,
-    dest_adapter_class=ccguard.RedisAdapter,
+    source_adapter_class=ccguard.WebAdapter,
+    dest_adapter_class=ccguard.SqliteAdapter,
     log_function=logging.debug,
 ):
     inner_callable = prepare_inner_callable(commit_id)
@@ -55,10 +55,14 @@ def parse_args(args=None):
     )
 
     parser.add_argument(
-        "source_adapter", help="Choose the adapter to use (choices: sqlite or redis)",
+        "source_adapter",
+        help="Choose the adapter to use (choices: sqlite or web)",
+        default="web",
     )
     parser.add_argument(
-        "dest_adapter", help="Choose the adapter to use (choices: sqlite or redis)",
+        "dest_adapter",
+        help="Choose the adapter to use (choices: sqlite or web)",
+        default="sqlite",
     )
     parser.add_argument(
         "--repository", dest="repository", help="the repository to analyze", default="."

--- a/ccguard/scripts/migrate_sqlite_database.py
+++ b/ccguard/scripts/migrate_sqlite_database.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 import sqlite3
 import lxml.etree as ET
 
@@ -17,6 +18,8 @@ def _get_line_coverage(data: bytes) -> (float, int, int):
 
 def _alter_table(conn, new_columns, table, sql):
     for name, ctype, default, not_null in new_columns:
+        if name == "branch" and name not in sql:
+            print(sql)
         if name not in sql:
             default_clause = "DEFAULT {}" if default else ""
             not_null_clause = "NOT NULL" if not_null else ""
@@ -69,6 +72,9 @@ def migration_steps_03_04(conn):
     ]
 
     for table, sql in tables:
+        if re.match(".*v[0-9]+$", table):
+            print("Skipping table {}".format(table))
+            continue
         print("Processing table {}".format(table))
         _alter_table(conn, new_columns, table, sql)
         _update_data(conn, table)
@@ -76,21 +82,84 @@ def migration_steps_03_04(conn):
 
 
 def migrate_03_04(dbpath):
-    print("Migrating database {}".format(dbpath))
+    print("Migrating database {} (0.3 to 0.6.2)".format(dbpath))
     try:
         conn = sqlite3.connect(dbpath)
         migration_steps_03_04(conn)
     finally:
         conn.close()
 
+MIGRATE_06_07 = """
+BEGIN TRANSACTION;
+
+ALTER TABLE timestamped_coverage_{repository_id} RENAME TO timestamped_coverage_{repository_id}_v0;
+
+CREATE TABLE IF NOT EXISTS `timestamped_coverage_{repository_id}_v1` (
+    `commit_id` varchar(40) NOT NULL,
+    `type` varchar(40) NOT NULL DEFAULT 'default',
+    `branch` varchar(70),
+    `collected_at` ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `count` INT DEFAULT 1,
+    `lts` INT DEFAULT 0,
+    `data` BLOB NOT NULL default '',
+    `line_rate` REAL DEFAULT 0.0,
+    `lines_covered` INT DEFAULT 0,
+    `lines_valid` INT DEFAULT 0,
+    PRIMARY KEY  (`commit_id`, `type`)
+);
+
+INSERT INTO timestamped_coverage_{repository_id}_v1
+    (commit_id, collected_at, count, lts, data,
+    line_rate, lines_covered, lines_valid)
+SELECT 
+    commit_id, collected_at, count, lts, coverage_data,
+    line_rate, lines_covered, lines_valid
+FROM timestamped_coverage_{repository_id}_v0;
+
+COMMIT;
+"""
+
+
+def migrate_06_07(dbpath):
+    print("Migrating database {} (0.6.2 to O.7)".format(dbpath))
+    try:
+        conn = sqlite3.connect(dbpath)
+        migration_steps_06_07(conn)
+    finally:
+        conn.close()
+
+
+def migration_steps_06_07(conn):
+    all_repositories = (
+        "SELECT name, sql FROM sqlite_master "
+        'WHERE type="table" AND name LIKE "timestamped_coverage_%"'
+    )
+
+    tables = conn.execute(all_repositories).fetchall()
+
+    for table, sql in tables:
+        if re.match(".*v[0-9]+$", table):
+            print("Skipping table {}".format(table))
+            continue
+        print("Processing table {}".format(table))
+        tokens = table.split("_")[2:]
+        if len(tokens) == 1:
+            repository_id = tokens[0]
+        else:
+            limit = -1 if re.match("v[0-9]+", tokens[-1]) else None
+            repository_id = "_".join(tokens[:limit])
+        instructions = MIGRATE_06_07.format(repository_id=repository_id)
+        conn.executescript(instructions)
+        conn.commit()
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=("Maintenance scripts for the given SQLite database.")
     )
-
     parser.add_argument(
         "dbpath", help="The SQLite database to maintain",
     )
     args = parser.parse_args()
     migrate_03_04(args.dbpath)
+    migrate_06_07(args.dbpath)

--- a/ccguard/test_ccguard.py
+++ b/ccguard/test_ccguard.py
@@ -14,6 +14,13 @@ def test_get_repository_id():
     )
 
 
+def test_get_repository_id_desambiguate():
+    assert (
+        ccguard.GitAdapter(repository_desambiguate="ccguard").get_repository_id()
+        == "a8858db8a0d483f8f6c8e74a5dc03b84bc9674f8_ccguard"
+    )
+
+
 def test_get_current_commit_id():
     val = ccguard.GitAdapter().get_current_commit_id()
     assert isinstance(val, str)
@@ -77,6 +84,17 @@ def test_parse_common():
     args = parser.parse_args(["--repository", "test", "--debug", "--adapter", "mine"])
     assert args.debug
     assert args.repository == "test"
+    assert args.adapter == "mine"
+
+
+def test_parse_common_repo_modifier():
+    parser = ccguard.parse_common_args()
+    args = parser.parse_args(
+        ["--repository", "test", "--debug", "--adapter", "mine", "-d", "mod"]
+    )
+    assert args.debug
+    assert args.repository == "test"
+    assert args.repository_id_modifier == "mod"
     assert args.adapter == "mine"
 
 

--- a/ccguard/test_ccguard_diff.py
+++ b/ccguard/test_ccguard_diff.py
@@ -16,7 +16,7 @@ def test_ccguard_diff():
     adapter = MagicMock()
 
     adapter.get_cc_commits = MagicMock(return_value=[commit1, "aaaa", commit2, "bbbb"])
-    adapter.retrieve_cc_data = MagicMock(side_effect=lambda commit: data[commit])
+    adapter.retrieve_cc_data = MagicMock(side_effect=lambda commit, **_: data[commit])
     adapter_class = MagicMock()
     adapter_class.__enter__ = MagicMock(return_value=adapter)
     adapter_factory = MagicMock(return_value=adapter_class)

--- a/ccguard/test_ccguard_sync.py
+++ b/ccguard/test_ccguard_sync.py
@@ -76,8 +76,8 @@ def test_parse_optionals():
 
 
 def test_parse_shortest():
-    args = ccguard_sync.parse_args(["redis", "sqlite"])
-    assert args.source_adapter == "redis"
+    args = ccguard_sync.parse_args(["web", "sqlite"])
+    assert args.source_adapter == "web"
     assert args.dest_adapter == "sqlite"
 
 
@@ -85,7 +85,7 @@ def test_main():
     commit = fake_commit()
     ccguard.adapter_factory = lambda a, b: mock_adapter_class(commit.hexsha)
     lines = []
-    ccguard_sync.main(["redis", "redis"], log_function=lambda *x: lines.append(x))
+    ccguard_sync.main(["web", "web"], log_function=lambda *x: lines.append(x))
     assert lines
 
 
@@ -94,6 +94,6 @@ def test_main_debug():
     ccguard.adapter_factory = lambda a, b: mock_adapter_class(commit.hexsha)
     lines = []
     ccguard_sync.main(
-        ["--debug", "redis", "redis"], log_function=lambda *x: lines.append(x)
+        ["--debug", "web", "web"], log_function=lambda *x: lines.append(x)
     )
     assert lines

--- a/common-distrib.sh
+++ b/common-distrib.sh
@@ -1,0 +1,11 @@
+rm dist/*.whl
+
+python3 -m venv env
+source env/bin/activate
+# install python packaging tools
+pip install wheel
+
+./update-version.sh
+
+# build this package
+python3 setup.py bdist_wheel

--- a/distrib.sh
+++ b/distrib.sh
@@ -1,21 +1,4 @@
-rm dist/*.whl
+./common-distrib.sh
 
-PKG_NAME=$(python setup.py --name)
-PKG_VERSION=$(python setup.py --version)
-sed -i "" "s/\(__version__ = \"\).*\(\"\)/\1${PKG_VERSION}\2/g" ccguard/__init__.py
-
-python3 -m venv env
-source env/bin/activate
-# install python packaging tools
-pip install wheel
-
-# keep in sync the version
-PKG_NAME=$(python setup.py --name)
-PKG_VERSION=$(python setup.py --version)
-
-sed -i "" "s/\(__version__ = \"\).*\(\"\)/\1${PKG_VERSION}\2/g" ccguard/__init__.py
-
-# build this package
-python3 setup.py bdist_wheel
-# install it
+# install this package
 python3 -m pip install -U dist/*.whl

--- a/release.sh
+++ b/release.sh
@@ -4,15 +4,12 @@
 #   - the section shall be named ccguard
 # - bump package version in setup.py
 
-PKG_NAME=$(python setup.py --name)
-PKG_VERSION=$(python setup.py --version)
-
-sed -i "" "s/\(__version__ = \"\).*\(\"\)/\1${PKG_VERSION}\2/g" ccguard/__init__.py
+. ./update-version.sh
 
 git add ccguard/__init__.py
 git commit -m "chore: bump version"
 
 git tag -am "release v${PKG_VERSION}" v${PKG_VERSION}
 git push --tags
-python setup.py bdist_wheel
+./common-distrib.sh
 twine upload --repository ccguard dist/${PKG_NAME}-${PKG_VERSION}-py3-none-any.whl

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     package_data={
         "": ["scripts/migrate_sqlite_database.py", "scripts/cleanup_database.py", "templates/index.html"],
     },
-    install_requires=["pycobertura", "gitpython", "redis", "flask", "requests", "lxml", "colour"],
+    install_requires=["pycobertura", "gitpython", "flask", "requests", "lxml", "colour"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ccguard",
-    version="0.6.1",
+    version="0.7.0",
     entry_points={
         "console_scripts": [
             "ccguard=ccguard.ccguard:main",

--- a/test_distrib/test_distrib.sh
+++ b/test_distrib/test_distrib.sh
@@ -1,12 +1,6 @@
-rm dist/*.whl
-rm -rf /tmp/venv
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+${DIR}/../common-distrib.sh
 
-PKG_NAME=$(python setup.py --name)
-PKG_VERSION=$(python setup.py --version)
-sed -i "" "s/\(__version__ = \"\).*\(\"\)/\1${PKG_VERSION}\2/g" ccguard/__init__.py
-
-pip install wheel
-python3 setup.py bdist_wheel
 python3 -m venv /tmp/venv
 source /tmp/venv/bin/activate
 cd /tmp/

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,0 +1,3 @@
+PKG_NAME=$(python setup.py --name)
+PKG_VERSION=$(python setup.py --version)
+sed -i "" "s/\(__version__ = \"\).*\(\"\)/\1${PKG_VERSION}\2/g" ccguard/__init__.py


### PR DESCRIPTION
ccguard retrieves the first commit ID and uses this as the repository ID. Generally this is a good approach since first commit IDs are random, and the only case where these IDs are not unique is the Birthday Paradox.

But, for repositories generated using `git-filter-branch`, this information is not unique. The first ID may be the same over several repositories, at the enterprise scope.

In this pull request we provide the caller an option to desambiguate the repository, like
```
ccguard report.xml  # in the original repository
ccguard -d first report.xml  # in the first repository originated from git-filter-branch
ccguard -d second report.xml  # in the second repository originated from git-filter-branch
```