### PR TITLE
feat: type specifier

### DIFF
--- a/ccguard/__init__.py
+++ b/ccguard/__init__.py
@@ -15,4 +15,4 @@ from .ccguard import (  # noqa
     get_output,
 )
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/ccguard/ccguard_diff.py
+++ b/ccguard/ccguard_diff.py
@@ -12,12 +12,13 @@ def print_diff_report(
     adapter,
     repository=".",
     repository_id_modifier=None,
+    subtype=None,
     pattern=None,
     log_function=print,
 ):
     dest = (pattern or "diff-{}-{}.html").format(first_ref, second_ref)
-    fdata = adapter.retrieve_cc_data(first_ref)
-    sdata = adapter.retrieve_cc_data(second_ref)
+    fdata = adapter.retrieve_cc_data(first_ref, subtype=subtype)
+    sdata = adapter.retrieve_cc_data(second_ref, subtype=subtype)
     first_fd = io.BytesIO(fdata)
     second_fd = io.BytesIO(sdata)
     source = ccguard.GitAdapter(repository, repository_id_modifier).get_root_path()
@@ -82,7 +83,7 @@ def main(args=None, log_function=print):
     second = ccguard.get_output(command, args.repository).rstrip("\n")
 
     with adapter_class(repo_id, config) as adapter:
-        refs = adapter.get_cc_commits()
+        refs = adapter.get_cc_commits(subtype=args.subtype)
         first_ref, second_ref = None, None
 
         for ref in refs:
@@ -100,6 +101,7 @@ def main(args=None, log_function=print):
                 adapter=adapter,
                 repository=args.repository,
                 repository_id_modifier=args.repository_id_modifier,
+                subtype=args.subtype,
                 pattern=args.report_file,
                 log_function=log_function,
             )

--- a/ccguard/ccguard_show.py
+++ b/ccguard/ccguard_show.py
@@ -19,6 +19,7 @@ def print_report(
     adapter,
     repository=".",
     repository_id_modifier=None,
+    subtype=None,
     pattern=None,
     log_function=print,
 ):
@@ -27,7 +28,7 @@ def print_report(
         "Printing the coverage report for the commit {} to {}".format(commit_id, dest)
     )
 
-    data = adapter.retrieve_cc_data(commit_id)
+    data = adapter.retrieve_cc_data(commit_id, subtype=subtype)
     reference_fd = io.BytesIO(data)
     source = ccguard.GitAdapter(repository, repository_id_modifier).get_root_path()
     reference_fd = normalize_report_paths(reference_fd, source)
@@ -77,7 +78,7 @@ def main(args=None, log_function=print):
     args.commit_id = ccguard.get_output(command, args.repository).rstrip("\n")
 
     with adapter_class(repo_id, config) as adapter:
-        refs = adapter.get_cc_commits()
+        refs = adapter.get_cc_commits(subtype=args.subtype)
 
         first_ref = None
         for ref in refs:
@@ -91,6 +92,7 @@ def main(args=None, log_function=print):
                 adapter=adapter,
                 repository=args.repository,
                 repository_id_modifier=args.repository_id_modifier,
+                subtype=args.subtype,
                 pattern=args.report_file,
                 log_function=log_function,
             )

--- a/ccguard/scripts/migrate_sqlite_database.py
+++ b/ccguard/scripts/migrate_sqlite_database.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 import sqlite3
 import lxml.etree as ET
 
@@ -17,6 +18,8 @@ def _get_line_coverage(data: bytes) -> (float, int, int):
 
 def _alter_table(conn, new_columns, table, sql):
     for name, ctype, default, not_null in new_columns:
+        if name == "branch" and name not in sql:
+            print(sql)
         if name not in sql:
             default_clause = "DEFAULT {}" if default else ""
             not_null_clause = "NOT NULL" if not_null else ""
@@ -69,6 +72,9 @@ def migration_steps_03_04(conn):
     ]
 
     for table, sql in tables:
+        if re.match(".*v[0-9]+$", table):
+            print("Skipping table {}".format(table))
+            continue
         print("Processing table {}".format(table))
         _alter_table(conn, new_columns, table, sql)
         _update_data(conn, table)
@@ -76,21 +82,84 @@ def migration_steps_03_04(conn):
 
 
 def migrate_03_04(dbpath):
-    print("Migrating database {}".format(dbpath))
+    print("Migrating database {} (0.3 to 0.6.2)".format(dbpath))
     try:
         conn = sqlite3.connect(dbpath)
         migration_steps_03_04(conn)
     finally:
         conn.close()
 
+MIGRATE_06_07 = """
+BEGIN TRANSACTION;
+
+ALTER TABLE timestamped_coverage_{repository_id} RENAME TO timestamped_coverage_{repository_id}_v0;
+
+CREATE TABLE IF NOT EXISTS `timestamped_coverage_{repository_id}_v1` (
+    `commit_id` varchar(40) NOT NULL,
+    `type` varchar(40) NOT NULL DEFAULT 'default',
+    `branch` varchar(70),
+    `collected_at` ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `count` INT DEFAULT 1,
+    `lts` INT DEFAULT 0,
+    `data` BLOB NOT NULL default '',
+    `line_rate` REAL DEFAULT 0.0,
+    `lines_covered` INT DEFAULT 0,
+    `lines_valid` INT DEFAULT 0,
+    PRIMARY KEY  (`commit_id`, `type`)
+);
+
+INSERT INTO timestamped_coverage_{repository_id}_v1
+    (commit_id, collected_at, count, lts, data,
+    line_rate, lines_covered, lines_valid)
+SELECT 
+    commit_id, collected_at, count, lts, coverage_data,
+    line_rate, lines_covered, lines_valid
+FROM timestamped_coverage_{repository_id}_v0;
+
+COMMIT;
+"""
+
+
+def migrate_06_07(dbpath):
+    print("Migrating database {} (0.6.2 to O.7)".format(dbpath))
+    try:
+        conn = sqlite3.connect(dbpath)
+        migration_steps_06_07(conn)
+    finally:
+        conn.close()
+
+
+def migration_steps_06_07(conn):
+    all_repositories = (
+        "SELECT name, sql FROM sqlite_master "
+        'WHERE type="table" AND name LIKE "timestamped_coverage_%"'
+    )
+
+    tables = conn.execute(all_repositories).fetchall()
+
+    for table, sql in tables:
+        if re.match(".*v[0-9]+$", table):
+            print("Skipping table {}".format(table))
+            continue
+        print("Processing table {}".format(table))
+        tokens = table.split("_")[2:]
+        if len(tokens) == 1:
+            repository_id = tokens[0]
+        else:
+            limit = -1 if re.match("v[0-9]+", tokens[-1]) else None
+            repository_id = "_".join(tokens[:limit])
+        instructions = MIGRATE_06_07.format(repository_id=repository_id)
+        conn.executescript(instructions)
+        conn.commit()
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=("Maintenance scripts for the given SQLite database.")
     )
-
     parser.add_argument(
         "dbpath", help="The SQLite database to maintain",
     )
     args = parser.parse_args()
     migrate_03_04(args.dbpath)
+    migrate_06_07(args.dbpath)

--- a/ccguard/test_ccguard_diff.py
+++ b/ccguard/test_ccguard_diff.py
@@ -16,7 +16,7 @@ def test_ccguard_diff():
     adapter = MagicMock()
 
     adapter.get_cc_commits = MagicMock(return_value=[commit1, "aaaa", commit2, "bbbb"])
-    adapter.retrieve_cc_data = MagicMock(side_effect=lambda commit: data[commit])
+    adapter.retrieve_cc_data = MagicMock(side_effect=lambda commit, **_: data[commit])
     adapter_class = MagicMock()
     adapter_class.__enter__ = MagicMock(return_value=adapter)
     adapter_factory = MagicMock(return_value=adapter_class)

--- a/common-distrib.sh
+++ b/common-distrib.sh
@@ -1,0 +1,11 @@
+rm dist/*.whl
+
+python3 -m venv env
+source env/bin/activate
+# install python packaging tools
+pip install wheel
+
+./update-version.sh
+
+# build this package
+python3 setup.py bdist_wheel

--- a/distrib.sh
+++ b/distrib.sh
@@ -1,21 +1,4 @@
-rm dist/*.whl
+./common-distrib.sh
 
-PKG_NAME=$(python setup.py --name)
-PKG_VERSION=$(python setup.py --version)
-sed -i "" "s/\(__version__ = \"\).*\(\"\)/\1${PKG_VERSION}\2/g" ccguard/__init__.py
-
-python3 -m venv env
-source env/bin/activate
-# install python packaging tools
-pip install wheel
-
-# keep in sync the version
-PKG_NAME=$(python setup.py --name)
-PKG_VERSION=$(python setup.py --version)
-
-sed -i "" "s/\(__version__ = \"\).*\(\"\)/\1${PKG_VERSION}\2/g" ccguard/__init__.py
-
-# build this package
-python3 setup.py bdist_wheel
-# install it
+# install this package
 python3 -m pip install -U dist/*.whl

--- a/release.sh
+++ b/release.sh
@@ -4,15 +4,12 @@
 #   - the section shall be named ccguard
 # - bump package version in setup.py
 
-PKG_NAME=$(python setup.py --name)
-PKG_VERSION=$(python setup.py --version)
-
-sed -i "" "s/\(__version__ = \"\).*\(\"\)/\1${PKG_VERSION}\2/g" ccguard/__init__.py
+. ./update-version.sh
 
 git add ccguard/__init__.py
 git commit -m "chore: bump version"
 
 git tag -am "release v${PKG_VERSION}" v${PKG_VERSION}
 git push --tags
-python setup.py bdist_wheel
+./common-distrib.sh
 twine upload --repository ccguard dist/${PKG_NAME}-${PKG_VERSION}-py3-none-any.whl

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ccguard",
-    version="0.6.1",
+    version="0.7.0",
     entry_points={
         "console_scripts": [
             "ccguard=ccguard.ccguard:main",

--- a/test_distrib/test_distrib.sh
+++ b/test_distrib/test_distrib.sh
@@ -1,12 +1,6 @@
-rm dist/*.whl
-rm -rf /tmp/venv
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+${DIR}/../common-distrib.sh
 
-PKG_NAME=$(python setup.py --name)
-PKG_VERSION=$(python setup.py --version)
-sed -i "" "s/\(__version__ = \"\).*\(\"\)/\1${PKG_VERSION}\2/g" ccguard/__init__.py
-
-pip install wheel
-python3 setup.py bdist_wheel
 python3 -m venv /tmp/venv
 source /tmp/venv/bin/activate
 cd /tmp/

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,0 +1,3 @@
+PKG_NAME=$(python setup.py --name)
+PKG_VERSION=$(python setup.py --version)
+sed -i "" "s/\(__version__ = \"\).*\(\"\)/\1${PKG_VERSION}\2/g" ccguard/__init__.py


### PR DESCRIPTION
When collecting code coverage, it might rever, for the same commit, to python3.7, python3.8, integration tests, unit tests.

With this pull request we provide support for specifying a different kind of code coverage.

Will allow us to merge code coverage, if `<line number= hits=>` elements are present in the cobertura.xml.

## Usage
```
ccguard -s py37 coverage.xml
ccguard --subtype py37 coverage.xml
```